### PR TITLE
refactor: 평균근무시간 사용자 이름 데이터 가져오는 부분 수정

### DIFF
--- a/src/features/home/components/AverageWorkTime.jsx
+++ b/src/features/home/components/AverageWorkTime.jsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import styled, { css } from 'styled-components'
 
 export default function AverageWorkTime() {
-  const { name } = useSelector((state) => state.user.name)
+  const { name } = useSelector((state) => state.user)
 
   const [isAnimated, setIsAnimated] = useState(false)
   useEffect(() => {


### PR DESCRIPTION
### ✨ Related Issues

- 이슈 넘버 #[issue_number]

### 📝 Task Details

- 평균근무시간 차트에 사용자 이름 표시안되는 현상 수정

## 💖 Review Requirements

- 구조분해할당 문법 사용해서 name만 가져왔는데  useSelector 할때 `state.user.name`으로 가져오면서 문제가 발생했네요!